### PR TITLE
Support building with CMake for Windows, SDL and X11 systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,29 +2,34 @@ name: Build
 
 on: [push, pull_request]
 
+env:
+  BUILD_TYPE: Release
+
 jobs:
   build-linux:
-    name: Linux (${{ matrix.linux.platform }})
+    name: Linux (${{ matrix.linux.system }})
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         linux:
-        - { platform: X11,  system: X, apt-packages: libx11-dev libxext-dev }
-        - { platform: SDL1, system: SDL, apt-packages: libsdl1.2-dev, sdl-config: sdl-config }
-        - { platform: SDL2, system: SDL, apt-packages: libsdl2-dev,   sdl-config: sdl2-config }
+        - { system: X,    apt-packages: libx11-dev libxext-dev }
+        - { system: SDL1, apt-packages: libsdl1.2-dev          }
+        - { system: SDL2, apt-packages: libsdl2-dev            }
 
     steps:
     - uses: actions/checkout@v3
     - name: Install dependencies
       if: ${{ matrix.linux.apt-packages != '' }}
       run: sudo apt-get update && sudo apt-get install ${{ matrix.linux.apt-packages }}
+    - name: Configure
+      run: cmake -B build/ -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DSYSTEM=${{ matrix.linux.system }} .
     - name: Build
-      run: make SYSTEM=${{ matrix.linux.system }} SDL_CONFIG=${{ matrix.linux.sdl-config }}
+      run: cmake --build build/ --config ${{env.BUILD_TYPE}} --parallel
     - uses: actions/upload-artifact@v3
       with:
         name: arcem-${{ matrix.linux.platform }}
-        path: ./arcem
+        path: ./build/arcem
 
   build-msvc:
     name: Windows (MSVC ${{ matrix.msvc.platform }})
@@ -33,19 +38,19 @@ jobs:
     strategy:
       matrix:
         msvc:
-        - { platform: Win32, artifact: vc/Release/ArcEm.exe }
-        - { platform: x64, artifact: vc/x64/Release/ArcEm.exe }
+        - { platform: Win32 }
+        - { platform: x64   }
 
     steps:
-    - name: Set up msbuild
-      uses: microsoft/setup-msbuild@v1.1.3
     - uses: actions/checkout@v3
+    - name: Configure
+      run: cmake -B build/ -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -A ${{ matrix.msvc.platform }} .
     - name: Build
-      run: msbuild vc/ArcEm.sln /m /p:BuildInParallel=true /p:Configuration=Release /p:Platform=${{ matrix.msvc.platform }}
+      run: cmake --build build/ --config ${{env.BUILD_TYPE}} --parallel
     - uses: actions/upload-artifact@v3
       with:
         name: arcem-msvc-${{ matrix.msvc.platform }}
-        path: ${{ matrix.msvc.artifact }}
+        path: build/Release/ArcEm.exe
 
   build-mingw:
     name: Windows (${{ matrix.mingw.msystem }})
@@ -66,14 +71,16 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: ${{ matrix.mingw.msystem }}
-        install: ${{ matrix.mingw.msys-env }}-cc make
+        install: ${{ matrix.mingw.msys-env }}-cc ${{ matrix.mingw.msys-env }}-cmake
     - uses: actions/checkout@v3
+    - name: Configure
+      run: cmake -B build/ -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} .
     - name: Build
-      run: make SYSTEM=win
+      run: cmake --build build/ --config ${{env.BUILD_TYPE}} --parallel
     - uses: actions/upload-artifact@v3
       with:
         name: arcem-${{ matrix.mingw.msystem }}
-        path: ./ArcEm.exe
+        path: ./build/ArcEm.exe
 
   build-watcom:
     name: Windows (OpenWatcom)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build*/
 armsuppmov.s
 armsuppmovs.s
 armsuppmvn.s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,199 @@
+cmake_minimum_required(VERSION 3.0.2...3.10)
+if(POLICY CMP0074)
+	cmake_policy(SET CMP0074 NEW)
+endif()
+project(ArcEm LANGUAGES C)
+
+set(ARCEM_SOURCES
+	armcopro.c
+	armdefs.h
+	armemu.c
+	armemu.h
+	arminit.c
+	armsupp.c
+	c99.h
+	dagstandalone.c
+	dagstandalone.h
+	eventq.c
+	eventq.h
+	main.c
+	prof.h
+)
+set(ARCEM_ARCH_SOURCES
+	arch/ArcemConfig.c
+	arch/ArcemConfig.h
+	arch/archio.c
+	arch/archio.h
+	arch/armarc.c
+	arch/armarc.h
+	arch/ControlPane.h
+	arch/cp15.c
+	arch/cp15.h
+	arch/dbugsys.h
+	arch/displaydev.c
+	arch/displaydev.h
+	arch/fdc1772.c
+	arch/fdc1772.h
+	arch/filecalls.h
+	arch/filecommon.c
+	arch/hdc63463.c
+	arch/hdc63463.h
+	arch/i2c.c
+	arch/i2c.h
+	arch/keyboard.c
+	arch/keyboard.h
+	arch/newsound.c
+	arch/sound.h
+	arch/Version.h
+)
+set(ARCEM_INIH_SOURCES
+	libs/inih/ini.c
+	libs/inih/ini.h
+)
+set(ARCEM_SDL_SOURCES
+	SDL/ControlPane.c
+	SDL/DispKbd.c
+	SDL/filecalls.c
+	SDL/filecalls_internal.h
+	SDL/fb.c
+	SDL/KeyTable.h
+	SDL/render.c
+)
+set(ARCEM_X_SOURCES
+	X/ControlPane.c
+	X/DispKbd.c
+	X/filecalls.c
+	X/filecalls_internal.h
+	X/KeyTable.h
+	X/platform.h
+	X/pseudo.c
+	X/true.c
+)
+set(ARCEM_VC_SOURCES
+	vc/dirent.h
+)
+set(ARCEM_WIN_SOURCES
+	win/ControlPane.c
+	win/DispKbd.c
+	win/filecalls.c
+	win/filecalls_internal.h
+	win/gui.h
+	win/gui.rc
+	win/KeyTable.h
+	win/win.c
+	win/win.h
+)
+
+if(WIN32)
+	set(DEFAULT_SYSTEM "win")
+elseif(UNIX AND NOT APPLE AND NOT HAIKU)
+	set(DEFAULT_SYSTEM "X")
+else()
+	set(DEFAULT_SYSTEM "SDL2")
+endif()
+set(SYSTEM ${DEFAULT_SYSTEM} CACHE STRING "System to compile for. Options: X SDL2 SDL1 win")
+set_property(CACHE SYSTEM PROPERTY STRINGS X SDL2 SDL1 win)
+
+option(EXTNROM_SUPPORT "Build with Extension ROM support" ON)
+if(EXTNROM_SUPPORT)
+	add_definitions(-DEXTNROM_SUPPORT)
+	list(APPEND ARCEM_ARCH_SOURCES arch/extnrom.c arch/extnrom.h)
+endif()
+
+option(HOSTFS_SUPPORT "Build with HostFS support" ON)
+if(HOSTFS_SUPPORT)
+	add_definitions(-DHOSTFS_SUPPORT)
+	list(APPEND ARCEM_SOURCES hostfs.c hostfs.h)
+endif()
+
+include(TestBigEndian)
+test_big_endian(HOST_BIGENDIAN)
+if(HOST_BIGENDIAN)
+	add_definitions(-DHOST_BIGENDIAN)
+endif(HOST_BIGENDIAN)
+
+if(${SYSTEM} MATCHES "^(SDL[12])$")
+	add_executable(arcem WIN32 ${ARCEM_SOURCES} ${ARCEM_ARCH_SOURCES} ${ARCEM_INIH_SOURCES} ${ARCEM_SDL_SOURCES})
+	target_include_directories(arcem PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/SDL)
+	target_compile_definitions(arcem PRIVATE SYSTEM_SDL USE_FAKEMAIN)
+
+	if(${SYSTEM} STREQUAL "SDL2")
+		find_package(SDL2 REQUIRED)
+		target_include_directories(arcem PRIVATE ${SDL2_INCLUDE_DIRS})
+		target_link_libraries(arcem PRIVATE ${SDL2_LIBRARIES})
+	elseif(${SYSTEM} STREQUAL "SDL1")
+		find_package(SDL REQUIRED)
+		target_include_directories(arcem PRIVATE ${SDL_INCLUDE_DIR})
+		target_link_libraries(arcem PRIVATE ${SDL_LIBRARY})
+	endif()
+elseif(${SYSTEM} STREQUAL "X")
+	option(SOUND_SUPPORT "Build with sound support" OFF)
+	option(SOUND_PTHREAD "Build with pthreads for sound support" ON)
+	if(SOUND_SUPPORT)
+		add_definitions(-DSOUND_SUPPORT)
+		list(APPEND ARCEM_X_SOURCES X/sound.c)
+	endif()
+
+	add_executable(arcem ${ARCEM_SOURCES} ${ARCEM_ARCH_SOURCES} ${ARCEM_INIH_SOURCES} ${ARCEM_X_SOURCES})
+	target_include_directories(arcem PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/X)
+	target_compile_definitions(arcem PRIVATE SYSTEM_X)
+
+	find_package(X11 REQUIRED)
+	target_include_directories(arcem PRIVATE ${X11_INCLUDE_DIRS})
+	target_link_libraries(arcem PRIVATE ${X11_LIBRARIES})
+
+	if(SOUND_SUPPORT AND SOUND_PTHREAD)
+		find_package(Threads REQUIRED)
+		target_link_libraries(Threads::Threads)
+	endif()
+elseif(${SYSTEM} STREQUAL "win")
+	option(SOUND_SUPPORT "Build with sound support" ON)
+	if(SOUND_SUPPORT)
+		add_definitions(-DSOUND_SUPPORT)
+		list(APPEND ARCEM_WIN_SOURCES win/sound.c)
+	endif()
+
+	add_executable(arcem WIN32 ${ARCEM_SOURCES} ${ARCEM_ARCH_SOURCES} ${ARCEM_INIH_SOURCES} ${ARCEM_WIN_SOURCES})
+	target_include_directories(arcem PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/win)
+	target_compile_definitions(arcem PRIVATE SYSTEM_win)
+
+	target_link_libraries(arcem PRIVATE comdlg32 gdi32 winmm)
+else()
+	message(FATAL_ERROR "Invalid system specified: ${SYSTEM}")
+endif()
+
+if(WIN32)
+	set_target_properties(arcem PROPERTIES OUTPUT_NAME "ArcEm")
+elseif(APPLE)
+	set_target_properties(arcem PROPERTIES
+		OUTPUT_NAME "ArcEm"
+		MACOSX_BUNDLE TRUE
+	)
+endif()
+
+target_include_directories(arcem PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/arch)
+if(MSVC)
+	target_compile_definitions(arcem PRIVATE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
+	target_sources(arcem PRIVATE ${ARCEM_VC_SOURCES})
+else()
+	if(NOT APPLE)
+		target_compile_definitions(arcem PRIVATE _LARGEFILE_SOURCE _LARGEFILE64_SOURCE _FILE_OFFSET_BITS=64)
+	endif()
+
+	target_compile_options(arcem PRIVATE -Wall -Wno-return-type -Wno-unknown-pragmas -Wshadow
+		   -Wpointer-arith -Wcast-align -Wstrict-prototypes
+		   -Wmissing-prototypes -Wmissing-declarations -Wnested-externs
+		   -Wcast-qual -Wwrite-strings -Wno-unused)
+	# TODO: Only add these for release builds
+	target_compile_options(arcem PRIVATE -funroll-loops -ffast-math -fomit-frame-pointer)
+	# These don't exist in Clang, and are enabled with -O2 when using GCC.
+	# -fexpensive-optimizations -frerun-cse-after-loop)
+endif()
+
+source_group(src FILES ${ARCEM_SOURCES})
+source_group(src\\arch FILES ${ARCEM_ARCH_SOURCES})
+source_group(src\\X FILES ${ARCEM_X_SOURCES})
+source_group(src\\SDL FILES ${ARCEM_SDL_SOURCES})
+source_group(src\\vc FILES ${ARCEM_VC_SOURCES})
+source_group(src\\win FILES ${ARCEM_WIN_SOURCES})
+source_group(libs\\inih FILES ${ARCEM_INIH_SOURCES})


### PR DESCRIPTION
The goal of this PR is to be able to eventually replace the Visual Studio and Xcode projects which are difficult to maintain outside of the respective IDEs. It also makes it easier to support other IDEs like VS Code, and reduces the complexity of building for platforms like the Nintendo DS and 3DS where more complex build rules are supplied by the toolchain.
